### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,8 +18,10 @@ path = [
 
     # code/ directory licensing
     "cleanup-storage/src/whitelist.json",
+    "code/fonts/**",
     "code/.husky/**",
     "code/.prettierrc",
+    "code/nodemon.json",
     "code/justfile",
     "code/.tool-versions",
     "code/tsconfig.base.json",

--- a/code/src/api/v1/controllers/workers/exportToImage.ts
+++ b/code/src/api/v1/controllers/workers/exportToImage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { parentPort } from "worker_threads";
 import sharp from "sharp";
 import { renderWeaveRoom } from "../../../../canvas/weave.js";

--- a/code/src/api/v1/controllers/workers/types.ts
+++ b/code/src/api/v1/controllers/workers/types.ts
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2025 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type ExportToImageWorkerResult = Buffer;

--- a/code/src/polyfills/canvas.ts
+++ b/code/src/polyfills/canvas.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // polyfills for Canvas in Node
 
 import { createCanvas, Image } from "canvas";

--- a/code/src/utils.ts
+++ b/code/src/utils.ts
@@ -32,9 +32,7 @@ export const saveBase64ToFile = async (
 ): Promise<void> => {
   // Define the safe root directory: <projectRoot>/temp
   const safeRoot = path.resolve(process.cwd(), "temp") + path.sep;
-  // Resolve the absolute file path
   const absFilePath = path.resolve(filePath);
-  // Ensure the target path is within the safe root
   if (!absFilePath.startsWith(safeRoot)) {
     throw new Error("Invalid or unsafe file path detected");
   }

--- a/code/src/utils.ts
+++ b/code/src/utils.ts
@@ -30,9 +30,17 @@ export const saveBase64ToFile = async (
   base64String: string,
   filePath: string
 ): Promise<void> => {
+  // Define the safe root directory: <projectRoot>/temp
+  const safeRoot = path.resolve(process.cwd(), "temp") + path.sep;
+  // Resolve the absolute file path
+  const absFilePath = path.resolve(filePath);
+  // Ensure the target path is within the safe root
+  if (!absFilePath.startsWith(safeRoot)) {
+    throw new Error("Invalid or unsafe file path detected");
+  }
   const buffer = Buffer.from(base64String, "base64");
-  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.promises.writeFile(filePath, buffer);
+  await fs.promises.mkdir(path.dirname(absFilePath), { recursive: true });
+  await fs.promises.writeFile(absFilePath, buffer);
 };
 
 export const sleep = (ms: number) =>

--- a/code/src/workers/workers.ts
+++ b/code/src/workers/workers.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { cpus } from "os";
 import { Worker } from "worker_threads";
 


### PR DESCRIPTION
Potential fix for [https://github.com/InditexTech/weavejs-backend/security/code-scanning/12](https://github.com/InditexTech/weavejs-backend/security/code-scanning/12)

The proper fix is to ensure that the file path constructed from user input always resides strictly within a designated "safe root" directory (in this case, likely the project’s `temp` directory). This involves:

- Normalizing and resolving the constructed path.
- Checking that the final path starts with the absolute path of the intended directory (e.g., the `temp` folder).
- Preventing file/directory creation if this check fails.

The best way to fix this with minimum changes is to perform these checks directly within `saveBase64ToFile` in `code/src/utils.ts`, since that function is the point where arbitrary paths are passed (and potentially used by other callers as well).

**Specifically:**
- First, compute the absolute path of `temp` (or whichever is the root directory for writing files) inside the function.
- Then, resolve the `filePath` as an absolute path.
- Ensure it starts with the intended root path (including the path separator to avoid partial match issues).
- If it doesn't, throw an exception or reject the operation.
- Proceed with `mkdir` and `writeFile` only if this check passes.

Add any required imports (only Node.js builtins are needed: `path`, which is already present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
